### PR TITLE
[feat]small_cardの開発

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,5 @@
   "less.validate": true,
   "css.lint.unknownAtRules": "ignore",
   "figma.autocompleteBlocks": true,
-  "prettier.bracketSameLine": true,
-  "files.autoSave": "off"
+  "prettier.bracketSameLine": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
   "less.validate": true,
   "css.lint.unknownAtRules": "ignore",
   "figma.autocompleteBlocks": true,
-  "prettier.bracketSameLine": true
+  "prettier.bracketSameLine": true,
+  "files.autoSave": "off"
 }

--- a/next/app/components/common/BigCard/BigCard.tsx
+++ b/next/app/components/common/BigCard/BigCard.tsx
@@ -25,6 +25,10 @@ export default function BigCard({ tokenInfo }: BigCardProps) {
             0,
           )
           const percentage = (expLogprob / totalExpLogprob) * 100
+          const variant =
+            displayToken(tokenInfo.token) === topLogprob.token
+              ? 'green'
+              : 'gray'
 
           return (
             <SmallCard
@@ -32,6 +36,7 @@ export default function BigCard({ tokenInfo }: BigCardProps) {
               token={topLogprob.token}
               percentage={percentage}
               displayToken={displayToken}
+              variant={variant}
             />
           )
         })}

--- a/next/app/components/common/SmallCard/SmallCard.module.css
+++ b/next/app/components/common/SmallCard/SmallCard.module.css
@@ -1,8 +1,8 @@
 .smallCard {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 8px;
-  background-color: #dcfce7;
   padding: 20px;
   width: 360px;
   height: 60px;
@@ -11,43 +11,23 @@
   font-weight: bold;
 }
 
-.smallCard p {
-  display: flex;
-  align-items: center;
-  font-size: 20px;
+.smallCard.green {
+  background-color: #dcfce7;
+}
+
+.smallCard.gray {
+  background-color: #f3f4f6;
 }
 
 .word {
   color: #117318;
-}
-
-.percent {
-  color: #333333;
-}
-
-.smallCard_other {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 8px;
-  background-color: #f3f4f6;
-  padding: 20px;
-  width: 360px;
-  height: 60px;
-  border-radius: 25px;
-  font-family: 'Montserrat';
-  font-weight: bold;
-}
-
-.smallCard_other p {
-  display: flex;
-  align-items: center;
   font-size: 20px;
 }
 
-.word_other {
+.word.gray {
   color: #927c74;
 }
 
-.percent_other {
+.percent {
   color: #333333;
 }

--- a/next/app/components/common/SmallCard/SmallCard.module.css
+++ b/next/app/components/common/SmallCard/SmallCard.module.css
@@ -1,7 +1,53 @@
 .smallCard {
+  display: flex;
+  justify-content: space-between;
   margin-bottom: 8px;
+  background-color: #dcfce7;
+  padding: 20px;
+  width: 360px;
+  height: 60px;
+  border-radius: 25px;
+  font-family: 'Montserrat';
+  font-weight: bold;
 }
 
-.smallCard strong {
-  display: block;
+.smallCard p {
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+}
+
+.word {
+  color: #117318;
+}
+
+.percent {
+  color: #333333;
+}
+
+.smallCard_other {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  background-color: #f3f4f6;
+  padding: 20px;
+  width: 360px;
+  height: 60px;
+  border-radius: 25px;
+  font-family: 'Montserrat';
+  font-weight: bold;
+}
+
+.smallCard_other p {
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+}
+
+.word_other {
+  color: #927c74;
+}
+
+.percent_other {
+  color: #333333;
 }

--- a/next/app/components/common/SmallCard/SmallCard.tsx
+++ b/next/app/components/common/SmallCard/SmallCard.tsx
@@ -8,9 +8,9 @@ export default function SmallCard({
   displayToken,
 }: SmallCardProps) {
   return (
-    <li className={styles.smallCard}>
-      <strong>{displayToken(token)}</strong>
-      <strong>{percentage.toFixed(2)}%</strong>
-    </li>
+    <div className={styles.smallCard}>
+      <p className={styles.word}>{displayToken(token)}</p>
+      <p className={styles.percent}>{percentage.toFixed(2)}%</p>
+    </div>
   )
 }

--- a/next/app/components/common/SmallCard/SmallCard.tsx
+++ b/next/app/components/common/SmallCard/SmallCard.tsx
@@ -6,10 +6,13 @@ export default function SmallCard({
   token,
   percentage,
   displayToken,
-}: SmallCardProps) {
+  variant = 'gray',
+}: SmallCardProps & { variant?: 'green' | 'gray' }) {
   return (
-    <div className={styles.smallCard}>
-      <p className={styles.word}>{displayToken(token)}</p>
+    <div className={`${styles.smallCard} ${styles[variant]}`}>
+      <p className={`${styles.word} ${variant === 'gray' ? styles.gray : ''}`}>
+        {displayToken(token)}
+      </p>
       <p className={styles.percent}>{percentage.toFixed(2)}%</p>
     </div>
   )

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "next",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.4.2",
         "@next-auth/prisma-adapter": "^1.0.7",


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
# 対応 Issue
- resolve #27


<!-- 開発内容の概要を記載 -->
# 概要
デザインに沿って、small_cardの開発をした。

<!-- 具体的な開発内容を記載 -->
# 実装内容
small_cardの開発をした。
next\app\components\common\SmallCard\SmallCard.module.css
では、「_other」付きのcssとそうでないcssに分け、それぞれの色を分けた。



<!-- URLとともに貼る（なければ空欄でよい） -->
# 画面スクリーンショット等
_otherなし
![スクリーンショット (45)](https://github.com/user-attachments/assets/0c192fb9-e8c2-4b42-8cd5-7a372b127f5b)

_otherあり
![スクリーンショット (44)](https://github.com/user-attachments/assets/bc803883-3c99-4482-a28a-07ff5f90ed68)

<!-- テストしてほしい内容を記載 -->
# テスト項目
- [x] デザインに問題ないか
- [ ]

# 備考