### PR TITLE
[feat]GenerateBoxのmargin追加

### DIFF
--- a/next/app/(default)/chatInterface/index.module.css
+++ b/next/app/(default)/chatInterface/index.module.css
@@ -1,10 +1,10 @@
 .heroContainer {
   width: 100%;
-  height: 45vh;
+  height: 55vh;
   display: flex;
   justify-content: center;
   text-align: center;
-  margin-top: 10vh;
+  align-items: center;
 }
 
 .hero {

--- a/next/app/components/common/GeneratedResultsBox/GeneratedResultsBox.module.css
+++ b/next/app/components/common/GeneratedResultsBox/GeneratedResultsBox.module.css
@@ -1,4 +1,6 @@
 .responseBox {
+  margin-left: 24px;
+  margin-right: 24px;
   background-color: #ffffff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 8px;

--- a/next/app/components/common/GeneratedResultsBox/GeneratedResultsBox.module.css
+++ b/next/app/components/common/GeneratedResultsBox/GeneratedResultsBox.module.css
@@ -1,6 +1,6 @@
 .responseBox {
-  margin-left: 24px;
-  margin-right: 24px;
+  margin-left: 12px;
+  margin-right: 12px;
   background-color: #ffffff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 8px;

--- a/next/app/components/common/SmallCard/SmallCard.module.css
+++ b/next/app/components/common/SmallCard/SmallCard.module.css
@@ -8,6 +8,7 @@
   border-radius: 25px;
   font-family: 'Montserrat';
   font-weight: bold;
+  text-wrap: nowrap;
 }
 
 .smallCard.green {

--- a/next/app/components/layouts/LogprobsDisplay/LogprobsDisplay.module.css
+++ b/next/app/components/layouts/LogprobsDisplay/LogprobsDisplay.module.css
@@ -1,19 +1,14 @@
+.container {
+  display: flex;
+  justify-content: center;
+}
+
 .grid {
   width: 90vw;
   display: grid;
   gap: 16px;
-  justify-content: center;
   margin: 2rem 0rem;
-}
-
-@media (min-width: 768px) {
-  .grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
-@media (max-width: 767px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  justify-content: center;
 }

--- a/next/app/components/layouts/LogprobsDisplay/LogprobsDisplay.tsx
+++ b/next/app/components/layouts/LogprobsDisplay/LogprobsDisplay.tsx
@@ -5,10 +5,12 @@ import BigCard from '@/components/common/BigCard'
 
 export default function LogprobsDisplay({ logprobs }: LogprobsDisplayProps) {
   return (
-    <div className={styles.grid}>
-      {logprobs.map((tokenInfo, index) => (
-        <BigCard key={index} tokenInfo={tokenInfo} />
-      ))}
+    <div className={styles.container}>
+      <div className={styles.grid}>
+        {logprobs.map((tokenInfo, index) => (
+          <BigCard key={index} tokenInfo={tokenInfo} />
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
# 対応 Issue
- resolve #46


<!-- 開発内容の概要を記載 -->
# 概要
GenerateBoxのmargin追加

<!-- 具体的な開発内容を記載 -->
# 実装内容
GenerateBoxのCSSに、左右のmarginを追加した。

<!-- URLとともに貼る（なければ空欄でよい） -->
# 画面スクリーンショット等
![スクリーンショット (49)](https://github.com/user-attachments/assets/9a4f5764-33f2-48c5-b314-ad58626490e1)


<!-- テストしてほしい内容を記載 -->
# テスト項目
- [ ] デザイン等に問題ないか

# 備考