### PR TITLE
[feat]プロンプト例文の追加

### DIFF
--- a/app/components/common/TemplatePrompt/TemplatePrompt.tsx
+++ b/app/components/common/TemplatePrompt/TemplatePrompt.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { FaEnvelope, FaPlane } from 'react-icons/fa'
+import { FaEnvelope, FaPlane, FaPenFancy, FaShoppingCart, FaUtensils } from 'react-icons/fa'
+import { IoLogoWechat } from 'react-icons/io5'
+import { SiLibreofficeimpress } from "react-icons/si";
+import { BiDetail } from "react-icons/bi";
+import { MdOutlineRateReview } from "react-icons/md";
 import styles from './TemplatePrompt.module.css'
 
 interface TemplatePromptProps {
@@ -16,11 +20,55 @@ const templates = [
       'あなたはビジネスマンです。クライアントに対して、プロジェクトの進捗報告メールを書いてください。',
   },
   {
+    title: '買い物リストの作成',
+    subTitle: '一週間分の食材リスト',
+    icon: <FaShoppingCart />,
+    prompt:
+      'あなたは家庭で料理をする人です。1週間分の食材の買い物リストを作成してください。',
+  },
+  {
+    title: '簡単な料理レシピ',
+    subTitle: '10分で作れる料理',
+    icon: <FaUtensils />,
+    prompt: '10分以内で作れる簡単な料理のレシピを提案してください。',
+  },
+  {
     title: '旅行プランの提案',
     subTitle: '東京の3泊4日旅行プラン',
     icon: <FaPlane />,
     prompt:
       'あなたは旅行代理店のスタッフです。3泊4日で楽しめる東京の旅行プランを提案してください。',
+  },
+  {
+    title: 'インタビューの質問',
+    subTitle: ' 作家へのインタビューのための質問のリスト',
+    icon: <FaPenFancy />,
+    prompt:
+      'あなたは記者です。作家へのインタビューのための質問のリストを作成してください。',
+  },
+  {
+    title: '賛否両論者',
+    subTitle: ' 特定のトピックの長所と短所を分析',
+    icon: <IoLogoWechat />,
+    prompt: 'リモートワークとオフィスワークの長所と短所を分析してください。',
+  },
+  {
+    title: '資料作成',
+    subTitle: ' 自社の新しいソフトウェアに関する資料作成',
+    icon: <SiLibreofficeimpress />,
+    prompt: 'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
+  },
+  {
+    title: '会議アジェンダ作成',
+    subTitle: ' 週次チームミーティングのアジェンダ',
+    icon: <BiDetail />,
+    prompt: 'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
+  },
+  {
+    title: '製品レビュー作成',
+    subTitle: ' 新製品のスマートフォンに関するレビュー',
+    icon: <MdOutlineRateReview />,
+    prompt: 'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
   },
 ]
 

--- a/app/components/common/TemplatePrompt/TemplatePrompt.tsx
+++ b/app/components/common/TemplatePrompt/TemplatePrompt.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
-import { FaEnvelope, FaPlane, FaPenFancy, FaShoppingCart, FaUtensils } from 'react-icons/fa'
+import {
+  FaEnvelope,
+  FaPlane,
+  FaPenFancy,
+  FaShoppingCart,
+  FaUtensils,
+} from 'react-icons/fa'
 import { IoLogoWechat } from 'react-icons/io5'
-import { SiLibreofficeimpress } from "react-icons/si";
-import { BiDetail } from "react-icons/bi";
-import { MdOutlineRateReview } from "react-icons/md";
+import { SiLibreofficeimpress } from 'react-icons/si'
+import { BiDetail } from 'react-icons/bi'
+import { MdOutlineRateReview } from 'react-icons/md'
 import styles from './TemplatePrompt.module.css'
 
 interface TemplatePromptProps {
@@ -56,19 +62,22 @@ const templates = [
     title: '資料作成',
     subTitle: ' 自社の新しいソフトウェアに関する資料作成',
     icon: <SiLibreofficeimpress />,
-    prompt: 'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
+    prompt:
+      'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
   },
   {
     title: '会議アジェンダ作成',
     subTitle: ' 週次チームミーティングのアジェンダ',
     icon: <BiDetail />,
-    prompt: 'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
+    prompt:
+      'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
   },
   {
     title: '製品レビュー作成',
     subTitle: ' 新製品のスマートフォンに関するレビュー',
     icon: <MdOutlineRateReview />,
-    prompt: 'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
+    prompt:
+      'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
   },
 ]
 


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->

# 対応 Issue

- resolve #70 

<!-- 開発内容の概要を記載 -->

# 概要

プロンプト例文を7個追加し、合計で9個にしました。
<!-- 具体的な開発内容を記載 -->

# 実装内容

要件に沿って以下のタイトルのプロンプト例文を作成しました。

1. 買い物リストの作成
2. 簡単な料理レシピ
3. インタビューの質問
4. 賛否両論者
5. 資料作成
6. 会議アジェンダ作成
7. 製品レビュー作成

<!-- URLとともに貼る（なければ空欄でよい） -->

# 画面スクリーンショット等

![スクリーンショット 2024-10-01 231121](https://github.com/user-attachments/assets/e9e17452-71aa-42c6-bd43-2982c78220b3)


# テスト項目

- [ ] Template Promptにプロンプト例文が追加されている

# 備考
現在のバージョンにpullしてから、画面のスクロールができなくなりました。開発者モードで画面下部まで写真を撮りました。