### PR TITLE
[feat]TemplatePromptModalのデザインの実装

### DIFF
--- a/app/components/common/Modal/TemplateModal/TemplateModal.module.css
+++ b/app/components/common/Modal/TemplateModal/TemplateModal.module.css
@@ -12,11 +12,45 @@
 }
 
 .modalContent {
-  background-color: #fff;
-  padding: 20px;
+  padding: 30px 40px 20px 40px;
   width: 80%;
   max-width: 500px;
-  border-radius: 5px;
+  border-radius: 30px;
+  border: 2px solid #cbd6e3;
+  background: #ffffff;
+}
+
+.closeButton {
+  position: relative;
+  bottom: 15px;
+  left: 220px;
+  background: none;
+  border: none;
+  font-size: 25px;
+  cursor: pointer;
+  color: #7b90a6;
+}
+
+.modalIntro {
+  text-align: left;
+}
+
+.modalTitle {
+  font-size: 22px;
+}
+.modalSubTitle {
+  stroke-width: 2px;
+  color: #2c3844;
+  stroke: #cbd6e3;
+  border-bottom: 2px solid #cbd6e3;
+  padding-bottom: 10px;
+  margin-top: 10px;
+  font-size: 14px;
+}
+
+.modalPrompt {
+  margin-top: 30px;
+  font-size: 14px;
 }
 
 .buttonGroup {
@@ -26,6 +60,22 @@
 }
 
 .buttonGroup button {
+  width: 50px;
   margin-left: 10px;
-  padding: 5px 10px;
+  padding: 5px 5px;
+}
+
+.insertButton {
+  background-color: #e0b1e8;
+  border-radius: 10px;
+  border: 2px solid #7b90a6;
+}
+
+.insertButton:hover {
+  transition:
+    background-color 0.3s,
+    color 0.3s,
+    border-color 0.3s;
+  background-color: rgba(224, 177, 232, 0.7);
+  border-color: rgba(123, 144, 166, 0.5);
 }

--- a/app/components/common/Modal/TemplateModal/TemplateModal.tsx
+++ b/app/components/common/Modal/TemplateModal/TemplateModal.tsx
@@ -20,7 +20,7 @@ const TemplateModal: React.FC<TemplateModalProps> = ({
   return (
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
-      <button className={styles.closeButton} onClick={onClose}>
+        <button className={styles.closeButton} onClick={onClose}>
           <RxCross1 />
         </button>
         <div className={styles.modalIntro}>

--- a/app/components/common/Modal/TemplateModal/TemplateModal.tsx
+++ b/app/components/common/Modal/TemplateModal/TemplateModal.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
+import { RxCross1 } from 'react-icons/rx'
 import styles from './TemplateModal.module.css'
 
 interface TemplateModalProps {
+  title: string
+  subTitle: string
   prompt: string
   onClose: () => void
   onInsert: () => void
 }
 
 const TemplateModal: React.FC<TemplateModalProps> = ({
+  title,
+  subTitle,
   prompt,
   onClose,
   onInsert,
@@ -15,11 +20,24 @@ const TemplateModal: React.FC<TemplateModalProps> = ({
   return (
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
-        <h3>テンプレートの内容</h3>
-        <p>{prompt}</p>
+      <button className={styles.closeButton} onClick={onClose}>
+          <RxCross1 />
+        </button>
+        <div className={styles.modalIntro}>
+          <div className={styles.modalTitle}>
+            <h3>{title}</h3>
+          </div>
+          <div className={styles.modalSubTitle}>
+            <p>{subTitle}</p>
+          </div>
+          <div className={styles.modalPrompt}>
+            <p>{prompt}</p>
+          </div>
+        </div>
         <div className={styles.buttonGroup}>
-          <button onClick={onInsert}>挿入</button>
-          <button onClick={onClose}>閉じる</button>
+          <button className={styles.insertButton} onClick={onInsert}>
+            挿入
+          </button>
         </div>
       </div>
     </div>

--- a/app/components/common/TemplatePrompt/TemplatePrompt.tsx
+++ b/app/components/common/TemplatePrompt/TemplatePrompt.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { FaEnvelope, FaPlane } from 'react-icons/fa'
+import { FaEnvelope, FaPlane, FaPenFancy, FaShoppingCart, FaUtensils } from 'react-icons/fa'
+import { IoLogoWechat } from 'react-icons/io5'
+import { SiLibreofficeimpress } from "react-icons/si";
+import { BiDetail } from "react-icons/bi";
+import { MdOutlineRateReview } from "react-icons/md";
 import styles from './TemplatePrompt.module.css'
 
 interface TemplatePromptProps {
@@ -16,11 +20,55 @@ const templates = [
       'あなたはビジネスマンです。クライアントに対して、プロジェクトの進捗報告メールを書いてください。',
   },
   {
+    title: '買い物リストの作成',
+    subTitle: '一週間分の食材リスト',
+    icon: <FaShoppingCart />,
+    prompt:
+      'あなたは家庭で料理をする人です。1週間分の食材の買い物リストを作成してください。',
+  },
+  {
+    title: '簡単な料理レシピ',
+    subTitle: '10分で作れる料理',
+    icon: <FaUtensils />,
+    prompt: '10分以内で作れる簡単な料理のレシピを提案してください。',
+  },
+  {
     title: '旅行プランの提案',
     subTitle: '東京の3泊4日旅行プラン',
     icon: <FaPlane />,
     prompt:
       'あなたは旅行代理店のスタッフです。3泊4日で楽しめる東京の旅行プランを提案してください。',
+  },
+  {
+    title: 'インタビューの質問',
+    subTitle: ' 作家へのインタビューのための質問のリスト',
+    icon: <FaPenFancy />,
+    prompt:
+      'あなたは記者です。作家へのインタビューのための質問のリストを作成してください。',
+  },
+  {
+    title: '賛否両論者',
+    subTitle: ' 特定のトピックの長所と短所を分析',
+    icon: <IoLogoWechat />,
+    prompt: 'リモートワークとオフィスワークの長所と短所を分析してください。',
+  },
+  {
+    title: '資料作成',
+    subTitle: ' 自社の新しいソフトウェアに関する資料作成',
+    icon: <SiLibreofficeimpress />,
+    prompt: 'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
+  },
+  {
+    title: '会議アジェンダ作成',
+    subTitle: ' 週次チームミーティングのアジェンダ',
+    icon: <BiDetail />,
+    prompt: 'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
+  },
+  {
+    title: '製品レビュー作成',
+    subTitle: ' 新製品のスマートフォンに関するレビュー',
+    icon: <MdOutlineRateReview />,
+    prompt: 'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
   },
 ]
 

--- a/app/components/common/TemplatePrompt/TemplatePrompt.tsx
+++ b/app/components/common/TemplatePrompt/TemplatePrompt.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
-import { FaEnvelope, FaPlane, FaPenFancy, FaShoppingCart, FaUtensils } from 'react-icons/fa'
+import {
+  FaEnvelope,
+  FaPlane,
+  FaPenFancy,
+  FaShoppingCart,
+  FaUtensils,
+} from 'react-icons/fa'
 import { IoLogoWechat } from 'react-icons/io5'
-import { SiLibreofficeimpress } from "react-icons/si";
-import { BiDetail } from "react-icons/bi";
-import { MdOutlineRateReview } from "react-icons/md";
+import { SiLibreofficeimpress } from 'react-icons/si'
+import { BiDetail } from 'react-icons/bi'
+import { MdOutlineRateReview } from 'react-icons/md'
 import styles from './TemplatePrompt.module.css'
 
 interface TemplatePromptProps {
@@ -56,19 +62,22 @@ const templates = [
     title: '資料作成',
     subTitle: ' 自社の新しいソフトウェアに関する資料作成',
     icon: <SiLibreofficeimpress />,
-    prompt: 'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
+    prompt:
+      'あなたは大手企業に勤めるソフトウェアの担当者です。新しいソフトウェアに関する資料の骨子を作成してください。',
   },
   {
     title: '会議アジェンダ作成',
     subTitle: ' 週次チームミーティングのアジェンダ',
     icon: <BiDetail />,
-    prompt: 'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
+    prompt:
+      'あなたはチームリーダーです。週次チームミーティングのためのアジェンダを作成してください。',
   },
   {
     title: '製品レビュー作成',
     subTitle: ' 新製品のスマートフォンに関するレビュー',
     icon: <MdOutlineRateReview />,
-    prompt: 'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
+    prompt:
+      'あなたはテクノロジーレビュアーです。最新のスマートフォンの製品レビューを作成してください。',
   },
 ]
 

--- a/app/components/common/TemplatePrompt/TemplatePrompt.tsx
+++ b/app/components/common/TemplatePrompt/TemplatePrompt.tsx
@@ -14,7 +14,7 @@ import styles from './TemplatePrompt.module.css'
 
 interface TemplatePromptProps {
   onSelectPrompt: (prompt: string) => void
-  onOpenModal: (prompt: string) => void
+  onOpenModal: (title: string, subTitle: string, prompt: string) => void
 }
 
 const templates = [
@@ -87,10 +87,12 @@ const TemplatePrompt: React.FC<TemplatePromptProps> = ({
 }) => {
   const handleKeyDown = (
     event: React.KeyboardEvent<HTMLDivElement>,
+    title: string,
+    subTitle: string,
     prompt: string,
   ) => {
     if (event.key === 'Enter' || event.key === ' ') {
-      onOpenModal(prompt)
+      onOpenModal(title, subTitle, prompt)
     }
   }
 
@@ -103,8 +105,17 @@ const TemplatePrompt: React.FC<TemplatePromptProps> = ({
               className={styles.cardContent}
               role="button"
               tabIndex={0}
-              onClick={() => onOpenModal(template.prompt)}
-              onKeyDown={(event) => handleKeyDown(event, template.prompt)}
+              onClick={() =>
+                onOpenModal(template.title, template.subTitle, template.prompt)
+              }
+              onKeyDown={(event) =>
+                handleKeyDown(
+                  event,
+                  template.title,
+                  template.subTitle,
+                  template.prompt,
+                )
+              }
             >
               <div className={styles.iconWrapper}>{template.icon}</div>
               <div className={styles.textContent}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,6 +41,8 @@ export default function Home() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [selectedOption, setSelectedOption] = useState('promptBox')
   const [isTemplateModalOpen, setIsTemplateModalOpen] = useState(false)
+  const [selectedTemplateTitle, setSelectedTemplateTitle] = useState('')
+  const [selectedTemplateSubTitle, setSelectedTemplateSubTitle] = useState('')
   const [selectedTemplatePrompt, setSelectedTemplatePrompt] = useState('')
 
   const toggleSidebar = () => {
@@ -200,7 +202,13 @@ export default function Home() {
     setIsTemplateModalOpen(false)
   }
 
-  const handleTemplateModalOpen = (prompt: string) => {
+  const handleTemplateModalOpen = (
+    title: string,
+    subTitle: string,
+    prompt: string,
+  ) => {
+    setSelectedTemplateTitle(title)
+    setSelectedTemplateSubTitle(subTitle)
     setSelectedTemplatePrompt(prompt)
     setIsTemplateModalOpen(true)
   }
@@ -329,6 +337,8 @@ export default function Home() {
 
           {isTemplateModalOpen && (
             <TemplateModal
+              title={selectedTemplateTitle}
+              subTitle={selectedTemplateSubTitle}
               prompt={selectedTemplatePrompt}
               onClose={handleTemplateModalClose}
               onInsert={() =>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->

# 対応 Issue

- resolve #76 

<!-- 開発内容の概要を記載 -->

# 概要
TemplatePromptのテンプレートカードモーダルのデザインを行った。
<!-- 具体的な開発内容を記載 -->

# 実装内容
テンプレートカードモーダルを要件通りのデザインに近づけた。
- TemplatePromptからTemplateModalへの`title`、`subTitle`、`prompt`の受け渡しはpage.tsxを通じて行いました。(ご教授いただきありがとうございました。)
- モーダルの背景色は他のモーダルが`#FFFFFF`のため他のモーダルに合わせました。

<!-- URLとともに貼る（なければ空欄でよい） -->

# 画面スクリーンショット等
![スクリーンショット 2024-10-04 093056](https://github.com/user-attachments/assets/03702f4e-96c1-4b02-8c86-e107845c8cea)
![スクリーンショット 2024-10-04 093124](https://github.com/user-attachments/assets/8370bcbd-cf1c-42ad-be49-72f90ba717df)


<!-- テストしてほしい内容を記載 -->

# テスト項目

- [ ] TemplatePromptを開くとそれぞれの内容が記載されたTemplateModalが確認できる。

# 備考
