### PR TITLE
[feat]80-サイトの日本語化

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -300,7 +300,8 @@ export default function Home() {
                 }
               >
                 <BsFillRocketTakeoffFill className={styles.icon} />
-                Prompt Box
+                {/* Prompt Box */}
+                プロンプトボックス
               </button>
               <button
                 onClick={() => setSelectedOption('thinkPromptTogether')}
@@ -311,7 +312,8 @@ export default function Home() {
                 }
               >
                 <BsChatTextFill className={styles.icon} />
-                Think of a prompt together
+                {/* Think of a prompt together */}
+                一緒にプロンプトを考える
               </button>
               <button
                 onClick={() => setSelectedOption('templatePrompt')}
@@ -320,7 +322,8 @@ export default function Home() {
                 }
               >
                 <IoMdBookmarks className={styles.icon} />
-                Template Prompt
+                {/* Template Prompt */}
+                プロンプトの例リスト
               </button>
             </div>
           </div>
@@ -337,9 +340,13 @@ export default function Home() {
               {selectedOption === 'promptBox' && (
                 <>
                   <div className={styles.hero}>
-                    <h1 className={styles.title}>Chat with an AI</h1>
+                    <h1 className={styles.title}>
+                      {/* Chat with an AI */}
+                      生成AIの言葉選びを見てみましょう
+                    </h1>
                     <h2 className={styles.subtitle}>
-                      Click on the gear icon to set the optimal parameters
+                      {/* Click on the gear icon to set the optimal parameters */}
+                      歯車アイコンをクリックしてパラメータを最適に
                     </h2>
                   </div>
                   <div className={styles.componentTop}>
@@ -363,7 +370,8 @@ export default function Home() {
                           className={styles.componentBottom}
                         >
                           <div className={styles.hideComponent}>
-                            <p>Expected Answer</p>
+                            {/* <p>Expected Answer</p> */}
+                            <p>出力したいテキスト</p>
                             <CorrectBox
                               correctText={correctText}
                               setCorrectText={setCorrectText}
@@ -378,9 +386,13 @@ export default function Home() {
               {selectedOption === 'thinkPromptTogether' && (
                 <>
                   <div className={styles.hero}>
-                    <h1 className={styles.title}>Create your prompt</h1>
+                    <h1 className={styles.title}>
+                      {/* Create your prompt */}
+                      あなたのプロンプトを作ります
+                      </h1>
                     <h2 className={styles.subtitle}>
-                      You can create a prompt just by answering a question
+                      {/* You can create a prompt just by answering a question */}
+                      幾つかの質問に答えるとプロンプトが完成
                     </h2>
                   </div>
                   <div className={styles.componentTop}>
@@ -391,9 +403,13 @@ export default function Home() {
               {selectedOption === 'templatePrompt' && (
                 <>
                   <div className={styles.hero}>
-                    <h1 className={styles.title}>Select the template</h1>
+                    <h1 className={styles.title}>
+                      {/* Select the template */}
+                      テンプレートを選んでください
+                      </h1>
                     <h2 className={styles.subtitle}>
-                      Click the insert button and use the prompt
+                      {/* Click the insert button and use the prompt */}
+                      テンプレートを選択し、プロンプトボックスに挿入
                     </h2>
                   </div>
                   <div className={styles.componentTop}>

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -389,7 +389,7 @@ export default function Home() {
                     <h1 className={styles.title}>
                       {/* Create your prompt */}
                       あなたのプロンプトを作ります
-                      </h1>
+                    </h1>
                     <h2 className={styles.subtitle}>
                       {/* You can create a prompt just by answering a question */}
                       幾つかの質問に答えるとプロンプトが完成
@@ -406,7 +406,7 @@ export default function Home() {
                     <h1 className={styles.title}>
                       {/* Select the template */}
                       テンプレートを選んでください
-                      </h1>
+                    </h1>
                     <h2 className={styles.subtitle}>
                       {/* Click the insert button and use the prompt */}
                       テンプレートを選択し、プロンプトボックスに挿入

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -323,7 +323,7 @@ export default function Home() {
               >
                 <IoMdBookmarks className={styles.icon} />
                 {/* Template Prompt */}
-                プロンプトの例リスト
+                プロンプトのテンプレート
               </button>
             </div>
           </div>

--- a/app/components/common/CorrectBox/CorrectBox.tsx
+++ b/app/components/common/CorrectBox/CorrectBox.tsx
@@ -29,7 +29,8 @@ export default function CorrectBox({
       <div className={styles.component}>
         <textarea
           ref={textareaRef}
-          placeholder="Enter correct text here..."
+          // placeholder="Enter correct text here..."
+          placeholder="出力したいテキストを入力してください"
           value={message}
           onChange={handleChange}
           className={styles.textarea}

--- a/app/components/common/FixPromptBox/FixPromptBox.tsx
+++ b/app/components/common/FixPromptBox/FixPromptBox.tsx
@@ -27,7 +27,8 @@ export default function FixPromptBox({
           <ReactMarkdown>{improvementSuggestions}</ReactMarkdown>
         </div>
       ) : (
-        <p>No improvement suggestions available</p>
+        // <p>No improvement suggestions available</p>
+        <p>改善提案はありません</p>
       )}
     </div>
   )

--- a/app/components/common/GenerateButton/GenerateButton.tsx
+++ b/app/components/common/GenerateButton/GenerateButton.tsx
@@ -26,7 +26,7 @@ export default function GenerateButton({
           (disabled || isLoading) && styles.disabled
         }`}
       >
-        {isLoading ? <div className={styles.loader}></div> : <p>Generate</p>}
+        {isLoading ? <div className={styles.loader}></div> : <p>生成する</p>}
       </button>
       {showTooltip && (
         <div className={styles.tooltip}>

--- a/app/components/common/GeneratedResultsBox/GeneratedResultsBox.tsx
+++ b/app/components/common/GeneratedResultsBox/GeneratedResultsBox.tsx
@@ -14,7 +14,8 @@ export default function GeneratedResultsBox({
 }: GenerationResultsProps) {
   return (
     <div className={styles.responseBox}>
-      <header>Generation Results</header>
+      {/* <header>Generation Results</header> */}
+      <header>生成結果</header>
       <div className={styles.responseBoxArea}>
         <ReactMarkdown className={styles.black}>{result}</ReactMarkdown>
       </div>

--- a/app/components/common/InputBox/InputBox.tsx
+++ b/app/components/common/InputBox/InputBox.tsx
@@ -49,7 +49,8 @@ export default function InputBox({
         <textarea
           ref={textareaRef}
           className={styles.textarea}
-          placeholder="Type your message..."
+          // placeholder="Type your message..."
+          placeholder="メッセージを入力してください"
           value={message}
           onChange={handleChange}
         />
@@ -71,7 +72,8 @@ export default function InputBox({
               />
             )}
             <div className={styles.iconIntro}>
-              <p>Enable Expected Answer</p>
+              {/* <p>Enable Expected Answer</p> */}
+              <p>採点機能を有効</p>
             </div>
           </div>
           <div className={styles.rightIcons}>

--- a/app/components/common/Modal/ConfigModal/ConfigModal.tsx
+++ b/app/components/common/Modal/ConfigModal/ConfigModal.tsx
@@ -118,8 +118,10 @@ export default function ConfigModal({
     <div className={styles.modalOverlay}>
       <div ref={modalRef} className={styles.modalContent}>
         <div className={styles.modalHeader}>
-          <h2>ChatGPT Configuration</h2>
-          <p>Customize your ChatGPT integration settings.</p>
+          {/* <h2>ChatGPT Configuration</h2> */}
+          <h2>ChatGPTの設定</h2>
+          {/* <p>Customize your ChatGPT integration settings.</p> */}
+          <p>ChatPGTのパラメータが変更できます。</p>
           <button className={styles.closeButton} onClick={handleCancel}>
             <RxCross1 />
           </button>
@@ -297,10 +299,10 @@ export default function ConfigModal({
         </div>
         <div className={styles.modalFooter}>
           <button className={styles.cancelButton} onClick={handleCancel}>
-            Cancel
+            戻る
           </button>
           <button className={styles.saveButton} onClick={handleSave}>
-            Save
+            保存
           </button>
         </div>
       </div>

--- a/app/components/common/Modal/TemplateModal/TemplateModal.module.css
+++ b/app/components/common/Modal/TemplateModal/TemplateModal.module.css
@@ -56,13 +56,13 @@
 .buttonGroup {
   display: flex;
   justify-content: flex-end;
-  margin-top: 20px;
+  margin-top: 32px;
 }
 
 .buttonGroup button {
-  width: 50px;
-  margin-left: 10px;
-  padding: 5px 5px;
+  width: 48px;
+  margin-left: 12px;
+  padding: 8px 8px;
 }
 
 .insertButton {


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->

# 対応 Issue

- resolve #80 

<!-- 開発内容の概要を記載 -->

# 概要
サイトの日本語化を行いました。
<!-- 具体的な開発内容を記載 -->

# 実装内容
- configModalの以下の部分やタイトルのprompt labみたいに固有名詞の英語の場合は英語のまま
- 日本語化するときは元々の文章はコメントアウトしています。
<!-- URLとともに貼る（なければ空欄でよい） -->

# 画面スクリーンショット等

![スクリーンショット 2024-10-05 101105](https://github.com/user-attachments/assets/9ee06fdb-4108-419c-9d4d-e22a369e8080)
![スクリーンショット 2024-10-05 101124](https://github.com/user-attachments/assets/deb50472-6f34-4cca-b7a4-be64586dce27)
![スクリーンショット 2024-10-05 101143](https://github.com/user-attachments/assets/9d6fe727-c0f3-44f6-825f-b59f75482135)
![スクリーンショット 2024-10-05 101159](https://github.com/user-attachments/assets/51b5e337-6ca6-4504-bc7f-ff162d674901)


# テスト項目

- [ ] 指定した箇所の日本語化ができているか
- [ ] 日本語のニュアンスとして正しいか

# 備考
